### PR TITLE
Lcg/better raises

### DIFF
--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -1,3 +1,7 @@
+
+raise "The compat_resources cookbook does not support chef versions older than Chef 12.0.0"
+  unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
+
 begin
   compat_resource_gem = Gem::Specification.find_by_name("compat_resource")
 rescue Gem::LoadError
@@ -18,5 +22,9 @@ else
 
   # The cookbook is the only copy; load the cookbook.
   $:.unshift File.expand_path("../../files/lib", __FILE__)
-  require 'chef_compat'
+  begin
+    require 'chef_compat'
+  rescue LoadError
+    raise "Could not find my own library file, this is most likely due to no_lazy_load being set to false, please see https://github.com/chef-cookbooks/compat_resource/issues/10"
+  end
 end

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -1,6 +1,6 @@
-
-raise "The compat_resources cookbook does not support chef versions older than Chef 12.0.0"
-  unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
+unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
+  raise "The compat_resources cookbook does not support chef versions older than Chef 12.0.0"
+end
 
 begin
   compat_resource_gem = Gem::Specification.find_by_name("compat_resource")

--- a/metadata.rb
+++ b/metadata.rb
@@ -2,3 +2,5 @@ name "compat_resource"
 description "Chef 12.5 Resources, For Chef 12.1-12.4"
 require_relative 'files/lib/chef_compat/version'
 version ChefCompat::VERSION
+
+chef_version ">= 12.0"

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,4 +3,4 @@ description "Chef 12.5 Resources, For Chef 12.1-12.4"
 require_relative 'files/lib/chef_compat/version'
 version ChefCompat::VERSION
 
-chef_version ">= 12.0"
+chef_version ">= 12.0" if respond_to?(:chef_version)


### PR DESCRIPTION
- raise if we're on Chef 11.x with a more useful error message
- catch the no_lazy_load false case and raise with useful info on that
- add chef_version ">= 12.0" to the metadata