### PR TITLE
move exception to resource parsing

### DIFF
--- a/files/lib/chef_compat.rb
+++ b/files/lib/chef_compat.rb
@@ -1,7 +1,22 @@
-require 'chef_compat/version'
-require 'chef_compat/resource'
-require 'chef_compat/property'
-require 'chef_compat/mixin/properties'
 
-module ChefCompat
+if Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
+
+  require 'chef_compat/version'
+  require 'chef_compat/resource'
+  require 'chef_compat/property'
+  require 'chef_compat/mixin/properties'
+
+  module ChefCompat
+  end
+
+else
+
+  class Chef
+    class Resource
+      def self.action(*args, &block)
+        raise "This resource is written with Chef 12.5 converged resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
+      end
+    end
+  end
+
 end

--- a/files/lib/chef_compat.rb
+++ b/files/lib/chef_compat.rb
@@ -13,7 +13,19 @@ else
 
   class Chef
     class Resource
-      def self.action(*args, &block)
+      def self.property(args, &block)
+        raise_chef_11_error
+      end
+
+      def self.resource_name(args, &block)
+        raise_chef_11_error
+      end
+
+      def self.action(args, &block)
+        raise_chef_11_error
+      end
+
+      def self.raise_chef_11_error
         raise "This resource is written with Chef 12.5 custom resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
       end
     end

--- a/files/lib/chef_compat.rb
+++ b/files/lib/chef_compat.rb
@@ -14,7 +14,7 @@ else
   class Chef
     class Resource
       def self.action(*args, &block)
-        raise "This resource is written with Chef 12.5 converged resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
+        raise "This resource is written with Chef 12.5 custom resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
       end
     end
   end

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -1,7 +1,3 @@
-unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
-  raise "The compat_resources cookbook does not support chef versions older than Chef 12.0.0"
-end
-
 begin
   compat_resource_gem = Gem::Specification.find_by_name("compat_resource")
 rescue Gem::LoadError


### PR DESCRIPTION
this moves the exception to resource parsing time.

since cookbooks that depend on compat_resource are written in Chef 12.5
style and all cookbooks that are synched have all their resources
loaded, i think this won't fix anyone.  the major benefit of throwing
the exception here is that users more clearly see which code is
inherently not supportable on Chef 11 and might stop blaming the
messenger.