### PR TITLE
Fix bug when running `chef-shell -z`

### DIFF
--- a/files/lib/chef_compat/monkeypatches/chef/recipe.rb
+++ b/files/lib/chef_compat/monkeypatches/chef/recipe.rb
@@ -6,6 +6,8 @@ class Chef::Recipe
   # instead of Chef::Recipe, for the extra goodies.
   def self.new(cookbook_name, recipe_name, run_context)
     if run_context &&
+      cookbook_name &&
+      recipe_name &&
       run_context.cookbook_collection &&
       run_context.cookbook_collection[cookbook_name] &&
       run_context.cookbook_collection[cookbook_name].metadata.dependencies.has_key?('compat_resource') &&


### PR DESCRIPTION
Fixes issue #25 

Error output as follows;
```
/opt/chef/embedded/apps/chef/lib/chef/cookbook/cookbook_collection.rb:38:in `block in initialize': Cookbook  not found. If you're loading  from another cookbook, make sure you configure the dependency in your metadata (Chef::Exceptions::CookbookNotFound)
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.5.0/lib/ohai/mash.rb:77:in `yield'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.5.0/lib/ohai/mash.rb:77:in `default'
        from /opt/chef/embedded/lib/ruby/gems/2.1.0/gems/ohai-8.5.0/lib/ohai/mash.rb:77:in `default'
        from /var/chef/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/recipe.rb:10:in `[]'
        from /var/chef/cache/cookbooks/compat_resource/files/lib/chef_compat/monkeypatches/chef/recipe.rb:10:in `new'
        from /opt/chef/embedded/apps/chef/lib/chef/shell/shell_session.rb:61:in `block in reset!'
        from /opt/chef/embedded/apps/chef/lib/chef/shell/shell_session.rb:101:in `loading'
        from /opt/chef/embedded/apps/chef/lib/chef/shell/shell_session.rb:54:in `reset!'
        from /opt/chef/embedded/apps/chef/lib/chef/shell.rb:128:in `session'
        from /opt/chef/embedded/apps/chef/lib/chef/shell.rb:137:in `init'
        from /opt/chef/embedded/apps/chef/lib/chef/shell.rb:65:in `start'
        from /opt/chef/embedded/apps/chef/bin/chef-shell:37:in `<top (required)>'
        from /usr/bin/chef-shell:55:in `load'
        from /usr/bin/chef-shell:55:in `<main>'
```