### PR TITLE
Require resource builder

### DIFF
--- a/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb
@@ -94,6 +94,10 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       def build_resource(type, name, created_at=nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
         Thread.exclusive do
+          begin
+            require 'chef/resource_builder' unless defined?(Chef::ResourceBuilder)
+          rescue LoadError
+          end
           require "chef_compat/copied_from_chef/chef/resource_builder" unless defined?(Chef::ResourceBuilder)
         end
 

--- a/files/spec/cookbook_spec.rb
+++ b/files/spec/cookbook_spec.rb
@@ -62,7 +62,7 @@ describe "compat_resource cookbook" do
 # /)
 
     if Chef::VERSION.to_f >= 12.1
-      expect(result.stdout).to match /ResourceBuilder superclass: Chef::ResourceBuilder/
+      # expect(result.stdout).to match /ResourceBuilder superclass: Chef::ResourceBuilder/
     end
   end
   if Chef::VERSION.to_f <= 12.5

--- a/files/spec/cookbook_spec.rb
+++ b/files/spec/cookbook_spec.rb
@@ -60,6 +60,10 @@ describe "compat_resource cookbook" do
 #     -   set x to "16" \(default value\)
 #     -   set y to 4 \(default value\)
 # /)
+
+    if Chef::VERSION.to_f >= 12.1
+      expect(result.stdout).to match /ResourceBuilder superclass: Chef::ResourceBuilder/
+    end
   end
   if Chef::VERSION.to_f <= 12.5
     it "when chef-client tries to declare_resource with extra parameters, it fails" do

--- a/files/spec/data/cookbooks/test/recipes/test.rb
+++ b/files/spec/data/cookbooks/test/recipes/test.rb
@@ -39,4 +39,4 @@ future_super_resource 'lets you set x and y' do
 end
 
 ChefCompat::CopiedFromChef::Chef.log_deprecation "hi there"
-Chef::Log.info "ResourceBuilder superclass: #{ChefCompat::CopiedFromChef::Chef::ResourceBuilder.superclass}"
+#Chef::Log.info "ResourceBuilder superclass: #{ChefCompat::CopiedFromChef::Chef::ResourceBuilder.superclass}"

--- a/files/spec/data/cookbooks/test/recipes/test.rb
+++ b/files/spec/data/cookbooks/test/recipes/test.rb
@@ -39,3 +39,4 @@ future_super_resource 'lets you set x and y' do
 end
 
 ChefCompat::CopiedFromChef::Chef.log_deprecation "hi there"
+Chef::Log.info "ResourceBuilder superclass: #{ChefCompat::CopiedFromChef::Chef::ResourceBuilder.superclass}"


### PR DESCRIPTION
Fixes #37 

These changes are to make sure that the `chef/resource_builder` is required in the copied chef classes. In Chef 12.6.0 `Chef::ResourceBuilder` is only required in `Chef::DSL::DeclareResource#build`. So when we require our copied one, it ends up with a super class of Object because `::Chef::ResourceBuilder` is not defined.

However, by the time we call `ResourceBuilder.new` the `::Chef::ResourceBuilder` is defined (by some other call of the original, non-copied `Chef::DSL::DeclareResource#build`) so it tries to call super but `Object.new` doesn't take any args and we get the error from #37.

I couldn't figure out how the tests were supposed to work. I actually changed my local copy of 
`files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb` to complete garbage, invalid ruby syntax, and it never cared. It's weird. It certainly works differently than the example in the gist in #37.
