### PR TITLE
Adding a require for the resource_builder so it doesn't accidently get loaded before the initialize is called

### DIFF
--- a/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb
@@ -20,8 +20,13 @@ module CopiedFromChef
 # limitations under the License.
 #
 
-# NOTE: this was extracted from the Recipe DSL mixin, relevant specs are in spec/unit/recipe_spec.rb
+begin
+  Thread.exclusive do
+    require "chef/resource_builder" unless defined?(::Chef::ResourceBuilder)
+  end
+rescue LoadError; end
 
+# NOTE: this was extracted from the Recipe DSL mixin, relevant specs are in spec/unit/recipe_spec.rb
 class Chef < (defined?(::Chef) ? ::Chef : Object)
   class ResourceBuilder < (defined?(::Chef::ResourceBuilder) ? ::Chef::ResourceBuilder : Object)
     attr_reader :type
@@ -36,7 +41,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
 
     # FIXME (ruby-2.1 syntax): most of these are mandatory
     def initialize(type:nil, name:nil, created_at: nil, params: nil, run_context: nil, cookbook_name: nil, recipe_name: nil, enclosing_provider: nil)
-super if defined?(::Chef::ResourceBuilder)
+      super if defined?(::Chef::ResourceBuilder)
       @type               = type
       @name               = name
       @created_at         = created_at


### PR DESCRIPTION
Delivery is currently seeing the following issue:

```
================================================================================
Recipe Compile Error in /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/delivery_delivery/recipes/default.rb
================================================================================

ArgumentError
-------------
wrong number of arguments (1 for 0)

Cookbook Trace:
---------------
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb:39:in `initialize'
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb:39:in `initialize'
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb:100:in `new'
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb:100:in `build_resource'
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb:67:in `declare_resource'
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/delivery_delivery/recipes/_db_dependencies.rb:31:in `from_file'
  /var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/delivery_delivery/recipes/default.rb:5:in `from_file'

Relevant File Content:
----------------------
/var/opt/delivery/workspace/delivery.shd.chef.co/Chef/Chef_Delivery/delivery/master/verify/unit/cache/cookbooks/compat_resource/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb:

 32:      attr_reader :cookbook_name
 33:      attr_reader :recipe_name
 34:      attr_reader :enclosing_provider
 35:      attr_reader :resource
 36:
 37:      # FIXME (ruby-2.1 syntax): most of these are mandatory
 38:      def initialize(type:nil, name:nil, created_at: nil, params: nil, run_context: nil, cookbook_name: nil, recipe_name: nil, enclosing_provider: nil)
 39>> super if defined?(::Chef::ResourceBuilder)
 40:        @type               = type
 41:        @name               = name
 42:        @created_at         = created_at
 43:        @params             = params
 44:        @run_context        = run_context
 45:        @cookbook_name      = cookbook_name
 46:        @recipe_name        = recipe_name
 47:        @enclosing_provider = enclosing_provider
 48:      end
```

We theorize that the following is happening:

1) The compat `resource_builder` file is getting required and loaded, which defines `Chef::ChefCompat::CopiedFromChef::Chef::ResourceBuilder` and extends Object because `::Chef::ResourceBuilder` isn't defined yet
2) Somewhere, `::Chef::ResourceBuilder` is getting defined
3) When the compat `resource_builder` gets initialized it calls `super` because `::Chef::ResourceBuilder` is now defined

\cc @lamont-granquist @danielsdeleo @jkeiser @mcquin

I have no idea how #2 would happen, but I wanted to get something out there to start a discussion of this issue