### PR TITLE
Copied files should require original if possible

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -89,6 +89,11 @@ task :update do
   chef_gem_path = Bundler.environment.specs['chef'].first.full_gem_path
   CHEF_FILES.each do |file|
     output = StringIO.new
+    # First lets try to load the original file if it exists
+    output.puts "begin"
+    output.puts "  require '#{file}'"
+    output.puts "rescue LoadError; end"
+    output.puts ""
     # Wrap the whole thing in a ChefCompat module
     output.puts "require 'chef_compat/copied_from_chef'"
     output.puts "class Chef"

--- a/files/lib/chef_compat/copied_from_chef/chef/constants.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/constants.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/constants'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -24,6 +28,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
   def NOT_PASSED.to_s
     "NOT_PASSED"
   end
+
   def NOT_PASSED.inspect
     to_s
   end

--- a/files/lib/chef_compat/copied_from_chef/chef/delayed_evaluator.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/delayed_evaluator.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/delayed_evaluator'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat

--- a/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/dsl/declare_resource.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/dsl/declare_resource'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -53,7 +57,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       #     action :delete
       #   end
       #
-      def declare_resource(type, name, created_at=nil, run_context: self.run_context, create_if_missing: false, &resource_attrs_block)
+      def declare_resource(type, name, created_at = nil, run_context: self.run_context, create_if_missing: false, &resource_attrs_block)
         created_at ||= caller[0]
 
         if create_if_missing
@@ -91,7 +95,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       #     action :delete
       #   end
       #
-      def build_resource(type, name, created_at=nil, run_context: self.run_context, &resource_attrs_block)
+      def build_resource(type, name, created_at = nil, run_context: self.run_context, &resource_attrs_block)
         created_at ||= caller[0]
         Thread.exclusive do
           require "chef_compat/copied_from_chef/chef/resource_builder" unless defined?(Chef::ResourceBuilder)
@@ -105,7 +109,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
           run_context:         run_context,
           cookbook_name:       cookbook_name,
           recipe_name:         recipe_name,
-          enclosing_provider:  self.is_a?(Chef::Provider) ? self :  nil,
+          enclosing_provider:  self.is_a?(Chef::Provider) ? self : nil,
         ).build(&resource_attrs_block)
       end
     end

--- a/files/lib/chef_compat/copied_from_chef/chef/dsl/recipe.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/dsl/recipe.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/dsl/recipe'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat

--- a/files/lib/chef_compat/copied_from_chef/chef/mixin/params_validate.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/mixin/params_validate.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/mixin/params_validate'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -146,7 +150,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       end
 
       # Raise an exception if the parameter is not found.
-      def _pv_required(opts, key, is_required=true, explicitly_allows_nil=false)
+      def _pv_required(opts, key, is_required = true, explicitly_allows_nil = false)
         if is_required
           return true if opts.has_key?(key.to_s) && (explicitly_allows_nil || !opts[key.to_s].nil?)
           return true if opts.has_key?(key.to_sym) && (explicitly_allows_nil || !opts[key.to_sym].nil?)
@@ -335,7 +339,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       #    property :x, name_property: true
       #   ```
       #
-      def _pv_name_property(opts, key, is_name_property=true)
+      def _pv_name_property(opts, key, is_name_property = true)
         if is_name_property
           if opts[key].nil?
             raise CannotValidateStaticallyError, "name_property cannot be evaluated without a resource." if self == Chef::Mixin::ParamsValidate
@@ -468,7 +472,6 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       # (which is the norm).
       extend self
 
-
       # Used by #set_or_return to avoid emitting a deprecation warning for
       # "value nil" and to keep default stickiness working exactly the same
       # @api private
@@ -482,7 +485,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
           value
         end
 
-        def call(resource, value=NOT_PASSED)
+        def call(resource, value = NOT_PASSED)
           # setting to nil does a get
           if value.nil? && !explicitly_accepts_nil?(resource)
             get(resource)

--- a/files/lib/chef_compat/copied_from_chef/chef/mixin/properties.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/mixin/properties.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/mixin/properties'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -24,7 +28,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
         #
         # @return [Hash<Symbol,Property>] The list of property names and types.
         #
-        def properties(include_superclass=true)
+        def properties(include_superclass = true)
           if include_superclass
             result = {}
             ancestors.reverse_each { |c| result.merge!(c.properties(false)) if c.respond_to?(:properties) }
@@ -99,10 +103,10 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
         # @example With type and options
         #   property :x, String, default: 'hi'
         #
-        def property(name, type=NOT_PASSED, **options)
+        def property(name, type = NOT_PASSED, **options)
           name = name.to_sym
 
-          options.each { |k,v| options[k.to_sym] = v if k.is_a?(String) }
+          options.each { |k, v| options[k.to_sym] = v if k.is_a?(String) }
 
           options[:instance_variable_name] = :"@#{name}" if !options.has_key?(:instance_variable_name)
           options.merge!(name: name, declared_in: self)
@@ -207,7 +211,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
 
             # If state_attrs *excludes* something which is currently desired state,
             # mark it as desired_state: false.
-            local_properties.each do |name,property|
+            local_properties.each do |name, property|
               if property.desired_state? && !names.include?(name)
                 self.property name, desired_state: false
               end
@@ -255,7 +259,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
 
             # If identity_properties *excludes* something which is currently part of
             # the identity, mark it as identity: false.
-            properties.each do |name,property|
+            properties.each do |name, property|
               if property.identity? && !names.include?(name)
 
                 self.property name, identity: false

--- a/files/lib/chef_compat/copied_from_chef/chef/property.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/property.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/property'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -89,11 +93,10 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
     #
     def initialize(**options)
 super if defined?(::Chef::Property)
-      options.each { |k,v| options[k.to_sym] = v; options.delete(k) if k.is_a?(String) }
+      options.each { |k, v| options[k.to_sym] = v; options.delete(k) if k.is_a?(String) }
       @options = options
       options[:name] = options[:name].to_sym if options[:name]
       options[:instance_variable_name] = options[:instance_variable_name].to_sym if options[:instance_variable_name]
-
 
       # Replace name_attribute with name_property
       if options.has_key?(:name_attribute)
@@ -102,7 +105,7 @@ super if defined?(::Chef::Property)
           raise ArgumentError, "Cannot specify both name_property and name_attribute together on property #{self}."
         end
         # replace name_property with name_attribute in place
-        options = Hash[options.map { |k,v| k == :name_attribute ? [ :name_property, v ] : [ k,v ] }]
+        options = Hash[options.map { |k, v| k == :name_attribute ? [ :name_property, v ] : [ k, v ] }]
         @options = options
       end
 
@@ -235,8 +238,8 @@ super if defined?(::Chef::Property)
     # @return [Hash<Symbol,Object>]
     #
     def validation_options
-      @validation_options ||= options.reject { |k,v|
-        [:declared_in,:name,:instance_variable_name,:desired_state,:identity,:default,:name_property,:coerce,:required].include?(k)
+      @validation_options ||= options.reject { |k, v|
+        [:declared_in, :name, :instance_variable_name, :desired_state, :identity, :default, :name_property, :coerce, :required].include?(k)
       }
     end
 
@@ -260,7 +263,7 @@ super if defined?(::Chef::Property)
     #   will be returned without running, validating or coercing. If it is a
     #   `get`, the non-lazy, coerced, validated value will always be returned.
     #
-    def call(resource, value=NOT_PASSED)
+    def call(resource, value = NOT_PASSED)
       if value == NOT_PASSED
         return get(resource)
       end
@@ -344,7 +347,7 @@ super if defined?(::Chef::Property)
            resource.enclosing_provider &&
            resource.enclosing_provider.new_resource &&
            resource.enclosing_provider.new_resource.respond_to?(name)
-           Chef::Log.warn("#{Chef::Log.caller_location}: property #{name} is declared in both #{resource} and #{resource.enclosing_provider}. Use new_resource.#{name} instead. At #{Chef::Log.caller_location}")
+          Chef::Log.warn("#{Chef::Log.caller_location}: property #{name} is declared in both #{resource} and #{resource.enclosing_provider}. Use new_resource.#{name} instead. At #{Chef::Log.caller_location}")
         end
 
         if has_default?
@@ -491,7 +494,7 @@ super if defined?(::Chef::Property)
       if modified_options.has_key?(:name_property) ||
          modified_options.has_key?(:name_attribute) ||
          modified_options.has_key?(:default)
-        options = options.reject { |k,v| k == :name_attribute || k == :name_property || k == :default }
+        options = options.reject { |k, v| k == :name_attribute || k == :name_property || k == :default }
       end
       self.class.new(options.merge(modified_options))
     end
@@ -508,7 +511,7 @@ super if defined?(::Chef::Property)
 
       # We prefer this form because the property name won't show up in the
       # stack trace if you use `define_method`.
-      declared_in.class_eval <<-EOM, __FILE__, __LINE__+1
+      declared_in.class_eval <<-EOM, __FILE__, __LINE__ + 1
         def #{name}(value=NOT_PASSED)
           raise "Property #{name} of \#{self} cannot be passed a block! If you meant to create a resource named #{name} instead, you'll need to first rename the property." if block_given?
           self.class.properties[#{name.inspect}].call(self, value)
@@ -520,7 +523,7 @@ super if defined?(::Chef::Property)
       EOM
     rescue SyntaxError
       # If the name is not a valid ruby name, we use define_method.
-      declared_in.define_method(name) do |value=NOT_PASSED, &block|
+      declared_in.define_method(name) do |value = NOT_PASSED, &block|
         raise "Property #{name} of #{self} cannot be passed a block! If you meant to create a resource named #{name} instead, you'll need to first rename the property." if block
         self.class.properties[name].call(self, value)
       end
@@ -579,7 +582,7 @@ super if defined?(::Chef::Property)
     # @api private
     def explicitly_accepts_nil?(resource)
       options.has_key?(:coerce) ||
-      (options.has_key?(:is) && resource.send(:_pv_is, { name => nil }, name, options[:is], raise_error: false))
+        (options.has_key?(:is) && resource.send(:_pv_is, { name => nil }, name, options[:is], raise_error: false))
     end
 
     def get_value(resource)

--- a/files/lib/chef_compat/copied_from_chef/chef/provider.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/provider.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/provider'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat

--- a/files/lib/chef_compat/copied_from_chef/chef/resource.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/resource'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -9,7 +13,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
   class Resource < (defined?(::Chef::Resource) ? ::Chef::Resource : Object)
     include Chef::Mixin::Properties
     property :name, String, coerce: proc { |v| v.is_a?(Array) ? v.join(", ") : v.to_s }, desired_state: false
-    def initialize(name, run_context=nil)
+    def initialize(name, run_context = nil)
 super if defined?(::Chef::Resource)
       name(name) unless name.nil?
       @run_context = run_context
@@ -38,7 +42,7 @@ super if defined?(::Chef::Resource)
       @elapsed_time = 0
       @sensitive = false
     end
-    def action(arg=nil)
+    def action(arg = nil)
       if arg
         arg = Array(arg).map(&:to_sym)
         arg.each do |action|
@@ -89,13 +93,13 @@ super if defined?(::Chef::Resource)
       end
       safe_ivars = instance_variables.map { |ivar| ivar.to_sym } - FORBIDDEN_IVARS
       safe_ivars.each do |iv|
-        key = iv.to_s.sub(/^@/,"").to_sym
+        key = iv.to_s.sub(/^@/, "").to_sym
         next if result.has_key?(key)
         result[key] = instance_variable_get(iv)
       end
       result
     end
-    def self.identity_property(name=nil)
+    def self.identity_property(name = nil)
       result = identity_properties(*Array(name))
       if result.size > 1
         raise Chef::Exceptions::MultipleIdentityError, "identity_property cannot be called on an object with more than one identity property (#{result.map { |r| r.name }.join(", ")})."
@@ -103,7 +107,7 @@ super if defined?(::Chef::Resource)
       result.first
     end
     attr_accessor :allowed_actions
-    def allowed_actions(value=NOT_PASSED)
+    def allowed_actions(value = NOT_PASSED)
       if value != NOT_PASSED
         self.allowed_actions = value
       end
@@ -128,7 +132,7 @@ super if defined?(::Chef::Resource)
     def self.allowed_actions=(value)
       @allowed_actions = value.uniq
     end
-    def self.default_action(action_name=NOT_PASSED)
+    def self.default_action(action_name = NOT_PASSED)
       unless action_name.equal?(NOT_PASSED)
         @default_action = Array(action_name).map(&:to_sym)
         self.allowed_actions |= @default_action

--- a/files/lib/chef_compat/copied_from_chef/chef/resource/action_class.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource/action_class.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/resource/action_class'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat
@@ -40,7 +44,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
           # We clear desired state in the copy, because it is supposed to be actual state.
           # We keep identity properties and non-desired-state, which are assumed to be
           # "control" values like `recurse: true`
-          current_resource.class.properties.each do |name,property|
+          current_resource.class.properties.each do |name, property|
             if property.desired_state? && !property.identity? && !property.name_property?
               property.reset(current_resource)
             end

--- a/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource_builder.rb
@@ -1,3 +1,7 @@
+begin
+  require 'chef/resource_builder'
+rescue LoadError; end
+
 require 'chef_compat/copied_from_chef'
 class Chef
 module ::ChefCompat


### PR DESCRIPTION
@jkeiser's suggested fix for #37.  The compat_resource files are loaded late enough that we _shouldn't_ have dependency or load order issues (because most of the original files will already have been `require`ed).

\cc @lamont-granquist @danielsdeleo @mcquin @jkeiser 