### PR TITLE
Verify that `CompatResource` is defined

### DIFF
--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -6,7 +6,7 @@ end
 # The user said they wanted this cookbook version, they need to have this cookbook version.
 # NOTE: if the gem is installed but on a different version, we simply don't care: the cookbook version wins.
 #       If another gem depends on a different version being there, rubygems will correctly throw the error.
-if defined?(ChefCompat)
+if defined?(ChefCompat) && defined?(CompatResource)
   version_rb = IO.read(File.expand_path("../../files/lib/compat_resource/version.rb", __FILE__))
   raise "Version file not in correct format" unless version_rb =~ /VERSION\s*=\s*'([^']+)'/
   cookbook_version = $1


### PR DESCRIPTION
### Description

Verify that `CompatResource` is loaded. If not, don't try to access it!

### Issues Resolved

Closes https://github.com/chef-cookbooks/compat_resource/issues/59

### Check List
- [ ] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


