### PR TITLE
Fix cookbook vs. gem detection under bundler.

### DIFF
--- a/files/lib/compat_resource.rb
+++ b/files/lib/compat_resource.rb
@@ -1,3 +1,5 @@
+require "chef/version"
+
 if Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERSION))
 
   require 'compat_resource/version'

--- a/files/lib/compat_resource/gemspec.rb
+++ b/files/lib/compat_resource/gemspec.rb
@@ -1,5 +1,5 @@
 if defined?(CompatResource::GEMSPEC)
-  raise "Already loaded ChefCompat from #{CompatResource::GEMSPEC.require_path}/compat_resource/gemspec.rb. Cannot load a second time from #{__FILE__}"
+  raise "Already loaded CompatResource from #{CompatResource::GEMSPEC.require_path}/compat_resource/gemspec.rb. Cannot load a second time from #{__FILE__}"
 end
 
 require_relative 'version'

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -6,13 +6,14 @@ end
 # The user said they wanted this cookbook version, they need to have this cookbook version.
 # NOTE: if the gem is installed but on a different version, we simply don't care: the cookbook version wins.
 #       If another gem depends on a different version being there, rubygems will correctly throw the error.
-if defined?(ChefCompat) && defined?(CompatResource)
+if Gem.loaded_specs["compat_resource"]
+  # Read our current version
   version_rb = IO.read(File.expand_path("../../files/lib/compat_resource/version.rb", __FILE__))
   raise "Version file not in correct format" unless version_rb =~ /VERSION\s*=\s*'([^']+)'/
   cookbook_version = $1
 
-  if CompatResource::VERSION != cookbook_version
-    raise "compat_resource gem version #{CompatResource::VERSION} was loaded as a gem before compat_resource cookbook version #{cookbook_version} was loaded. To remedy this, either update the cookbook to the gem version, update the gem to the cookbook version, or uninstall / stop loading the gem so early."
+  unless Gem.loaded_specs["compat_resource"].version == Gem::Version.new(cookbook_version)
+    raise "compat_resource gem version #{Gem.loaded_specs["compat_resource"].version} was loaded as a gem before compat_resource cookbook version #{cookbook_version} was loaded. To remedy this, either update the cookbook to the gem version, update the gem to the cookbook version, or uninstall / stop loading the gem so early."
   end
 else
   # The gem is not already activated, so activate the cookbook.


### PR DESCRIPTION
### Description

Makes the cookbook not trigger errors under bundler.

When we're running in bundler, the gem may be "loaded" without
actually having required any files, so our check for a constant
is not the right way to do it. Instead, just ask rubygems.

### Issues Resolved

chef-ingredient `master` is failing.

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD