### PR TITLE
Warn about ignored before-notifications

### DIFF
--- a/files/lib/chef_compat/monkeypatches/chef/runner.rb
+++ b/files/lib/chef_compat/monkeypatches/chef/runner.rb
@@ -37,6 +37,11 @@ class Chef
     # Determine the appropriate provider for the given resource, then
     # execute it.
     def run_action(resource, action, notification_type = nil, notifying_resource = nil)
+      before_notifications = run_context.before_notifications(resource) || []
+      unless before_notifications.empty?
+        Chef::Log.warn("The cookbook compat_resource has patched the chef_runner to enable the enhanced notifications from chef 12.10. Your :before-notification for #{resource} will not be executed")
+      end
+
       # Actually run the action for realsies
       resource.run_action(action, notification_type, notifying_resource)
 

--- a/files/lib/chef_compat/monkeypatches/chef/runner.rb
+++ b/files/lib/chef_compat/monkeypatches/chef/runner.rb
@@ -37,7 +37,8 @@ class Chef
     # Determine the appropriate provider for the given resource, then
     # execute it.
     def run_action(resource, action, notification_type = nil, notifying_resource = nil)
-      before_notifications = run_context.before_notifications(resource) || []
+      before_notifications = run_context.respond_to?(:before_notifications) ? run_context.before_notifications(resource) : nil
+      before_notifications = before_notifications || []
       unless before_notifications.empty?
         Chef::Log.warn("The cookbook compat_resource has patched the chef_runner to enable the enhanced notifications from chef 12.10. Your :before-notification for #{resource} will not be executed")
       end


### PR DESCRIPTION
This sent me down quite the rabbit hole today, because this patched
version silently ignores :before-notifications. This patch at least adds
a warning to all chef logs that :before notifications are ignored here,
which makes it easier to troubleshoot issues with this.

This change will also mitigate #66 by telling the user. It's no fix, but
it's less confusing this way.