### PR TITLE
Skip autoload for recent chef-client versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ To use this cookbook, put `depends 'compat_resource'` in the metadata.rb of your
 
 For example, if you create resources/myresource.rb, myresource can use `property`, `load_current_value` and `action` (no need to create a provider). If you want to create Resource classes directly, extend from `ChefCompat::Resource` instead of `Chef::Resource`. Properties, current value loading, converge_if_changed, and resource_name will all function the same across versions.
 
+NB: This cookbook does not do anything on recent (>= 12.5) chef versions.
+
 ## Custom Resources?
 
 Curious about how to use custom resources? Here are the 12.5 docs:

--- a/files/spec/data/cookbooks/empty/metadata.rb
+++ b/files/spec/data/cookbooks/empty/metadata.rb
@@ -1,0 +1,4 @@
+name "empty"
+description "cookbook that does nothing but depends on compat_resource"
+version "1.0.0"
+depends 'compat_resource'

--- a/files/spec/data/cookbooks/empty/recipes/default.rb
+++ b/files/spec/data/cookbooks/empty/recipes/default.rb
@@ -1,0 +1,1 @@
+raise "CompatResource defined on recent chef" if defined?(ChefCompat::Resource) && Gem::Requirement.new(">= 12.5").satisfied_by?(Gem::Version.new(Chef::VERSION)) 

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -2,23 +2,28 @@ unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERS
   raise "This resource is written with Chef 12.5 custom resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
 end
 
-# If the gem is already activated rather than the cookbook, then we fail if our version is DIFFERENT.
-# The user said they wanted this cookbook version, they need to have this cookbook version.
-# NOTE: if the gem is installed but on a different version, we simply don't care: the cookbook version wins.
-#       If another gem depends on a different version being there, rubygems will correctly throw the error.
-if Gem.loaded_specs["compat_resource"]
-  # Read our current version
-  version_rb = IO.read(File.expand_path("../../files/lib/compat_resource/version.rb", __FILE__))
-  raise "Version file not in correct format" unless version_rb =~ /VERSION\s*=\s*'([^']+)'/
-  cookbook_version = $1
-
-  unless Gem.loaded_specs["compat_resource"].version == Gem::Version.new(cookbook_version)
-    raise "compat_resource gem version #{Gem.loaded_specs["compat_resource"].version} was loaded as a gem before compat_resource cookbook version #{cookbook_version} was loaded. To remedy this, either update the cookbook to the gem version, update the gem to the cookbook version, or uninstall / stop loading the gem so early."
-  end
+if Gem::Requirement.new(">= 12.5").satisfied_by?(Gem::Version.new(Chef::VERSION))
+  Chef::Log.info "Your chef installation is newer than 12.5, skipping compat_resource loading"
 else
-  # The gem is not already activated, so activate the cookbook.
-  require_relative '../files/lib/compat_resource/gemspec'
-  CompatResource::GEMSPEC.activate
-end
 
-require 'compat_resource'
+  # If the gem is already activated rather than the cookbook, then we fail if our version is DIFFERENT.
+  # The user said they wanted this cookbook version, they need to have this cookbook version.
+  # NOTE: if the gem is installed but on a different version, we simply don't care: the cookbook version wins.
+  #       If another gem depends on a different version being there, rubygems will correctly throw the error.
+  if Gem.loaded_specs["compat_resource"]
+    # Read our current version
+    version_rb = IO.read(File.expand_path("../../files/lib/compat_resource/version.rb", __FILE__))
+    raise "Version file not in correct format" unless version_rb =~ /VERSION\s*=\s*'([^']+)'/
+    cookbook_version = $1
+
+    unless Gem.loaded_specs["compat_resource"].version == Gem::Version.new(cookbook_version)
+      raise "compat_resource gem version #{Gem.loaded_specs["compat_resource"].version} was loaded as a gem before compat_resource cookbook version #{cookbook_version} was loaded. To remedy this, either update the cookbook to the gem version, update the gem to the cookbook version, or uninstall / stop loading the gem so early."
+    end
+  else
+    # The gem is not already activated, so activate the cookbook.
+    require_relative '../files/lib/compat_resource/gemspec'
+    CompatResource::GEMSPEC.activate
+  end
+
+  require 'compat_resource'
+end


### PR DESCRIPTION
### Description

It does not seems to be necessary to provide new resource mechanisms to
recent (>= 12.5) chef-clients since they already have it.

Loading code to modify chef behavior proved risky (see #66).

### Issues Resolved

Fixes #66
Fixes #75, #76 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD