### PR TITLE
replace warning with raise

### DIFF
--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -2,24 +2,13 @@ unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERS
   raise "This resource is written with Chef 12.5 custom resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
 end
 
-# If the gem is already activated rather than the cookbook, then we fail if our version is DIFFERENT.
-# The user said they wanted this cookbook version, they need to have this cookbook version.
-# NOTE: if the gem is installed but on a different version, we simply don't care: the cookbook version wins.
-#       If another gem depends on a different version being there, rubygems will correctly throw the error.
+# we no longer support loading with a gem
 if Gem.loaded_specs["compat_resource"]
-  Chef.log_deprecation "using compat_resource as a gem is deprecated and will be removed in a future version of this cookbook"
-  # Read our current version
-  version_rb = IO.read(File.expand_path("../../files/lib/compat_resource/version.rb", __FILE__))
-  raise "Version file not in correct format" unless version_rb =~ /VERSION\s*=\s*'([^']+)'/
-  cookbook_version = $1
-
-  unless Gem.loaded_specs["compat_resource"].version == Gem::Version.new(cookbook_version)
-    raise "compat_resource gem version #{Gem.loaded_specs["compat_resource"].version} was loaded as a gem before compat_resource cookbook version #{cookbook_version} was loaded. To remedy this, either update the cookbook to the gem version, update the gem to the cookbook version, or uninstall / stop loading the gem so early."
-  end
-else
-  # The gem is not already activated, so activate the cookbook.
-  require_relative '../files/lib/compat_resource/gemspec'
-  CompatResource::GEMSPEC.activate
+  raise "using compat_resource as a gem is deprecated;  please update your gems to cheffish >= 3.0.0 and chef-provisioning >= 1.9.1 to eliminate it"
 end
+
+# The gem is not already activated, so activate the cookbook.
+require_relative '../files/lib/compat_resource/gemspec'
+CompatResource::GEMSPEC.activate
 
 require 'compat_resource'


### PR DESCRIPTION
this follows the pattern of "if you want the latest you need to be on the latest"

users that cannot update cheffish/chef-provisioning will need to manually pin to prior versions of compat_resource.

upgrading all three will work together consistently.
