### PR TITLE
back to a deprecation warning

### DIFF
--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -2,12 +2,14 @@ unless Gem::Requirement.new(">= 12.0").satisfied_by?(Gem::Version.new(Chef::VERS
   raise "This resource is written with Chef 12.5 custom resources, and requires at least Chef 12.0 used with the compat_resource cookbook, it will not work with Chef 11.x clients, and those users must pin their cookbooks to older versions or upgrade."
 end
 
-# we no longer support loading with a gem
+# If users are on old verisons of ChefDK which activates an (old) gem via cheffish before this cookbook loads, then
+# we just try to monkeypatch over the top of a monkeypatch.  Its possible that we have checks in this cookbook which
+# will defeat that purpose and fail to monkeypatch on top of monkeypatches -- in which case those checks should be
+# removed -- this cookbook needs to win when it gets into a fight with the old gem versions.
 if Gem.loaded_specs["compat_resource"]
-  raise "using compat_resource as a gem is deprecated;  please update your gems to cheffish >= 3.0.0 and chef-provisioning >= 1.9.1 to eliminate it"
+  Chef.log_deprecation "using compat_resource as a gem is deprecated;  please update cheffish and chef-provisioning gems (or use the latest Chef/ChefDK packages) or else manually pin your compat_resource cookbook version to the same version as the gem you are using to remove this warning"
 end
 
-# The gem is not already activated, so activate the cookbook.
 require_relative '../files/lib/compat_resource/gemspec'
 CompatResource::GEMSPEC.activate
 


### PR DESCRIPTION


i think this is actually better.  users on old chef + chef-dk omnibus
binaries will be broken by slurping down the new compat_resource
cookbook.  they only path out of it is upgrading their chef + chef-dk
packages -- but the whole point of compat_resource is so that people
who don't ever upgrade don't block community cookbook development.

so we need to make this work.  we're already monkeypatching over the
top of a dozen old chef-client versions, we might as well monkeypatch
over the top of our old monkeypatches as well.

the general rule we're going to start following around here is that if
you're making the choice to monkeypatch code you need to assert that
you always win any argument.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>