### PR TITLE
keep ChefCompat::Resource defined even if we don't load

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,8 @@ rvm:
 
 matrix:
   include:
-# since we no longer load anything on chef versions later than what we were created from, but since
-# the rspec tests in here all assume we're loaded, we can no longer usefully test against chef/chef master
-#    - env: "GEMFILE_MOD=\"gem 'chef', github: 'chef/chef'\""
-#      rvm: 2.3.1
+    - env: "GEMFILE_MOD=\"gem 'chef', github: 'chef/chef'\""
+      rvm: 2.3.1
     - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.12.0'\""
       rvm: 2.1
     - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.11.0'\""

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -20,4 +20,8 @@ if Gem::Requirement.new("< #{ChefCompat::CHEF_UPSTREAM_VERSION}").satisfied_by?(
   require 'compat_resource'
 else
   Chef::Log.debug "NOT LOADING compat_resource based on chef-version #{ChefCompat::CHEF_UPSTREAM_VERSION} over chef version #{Gem::Version.new(Chef::VERSION)}"
+  module ChefCompat
+    class Resource < Chef::Resource
+    end
+  end
 end

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -23,5 +23,9 @@ else
   module ChefCompat
     class Resource < Chef::Resource
     end
+    module Mixin
+      module Properties < Chef::Mixin::Properties
+      end
+    end
   end
 end

--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -21,11 +21,9 @@ if Gem::Requirement.new("< #{ChefCompat::CHEF_UPSTREAM_VERSION}").satisfied_by?(
 else
   Chef::Log.debug "NOT LOADING compat_resource based on chef-version #{ChefCompat::CHEF_UPSTREAM_VERSION} over chef version #{Gem::Version.new(Chef::VERSION)}"
   module ChefCompat
-    class Resource < Chef::Resource
-    end
+    Resource = Chef::Resource
     module Mixin
-      module Properties < Chef::Mixin::Properties
-      end
+      Properties = Chef::Mixin::Properties
     end
   end
 end

--- a/spec/data/cookbooks/test/recipes/test.rb
+++ b/spec/data/cookbooks/test/recipes/test.rb
@@ -38,4 +38,4 @@ future_super_resource 'lets you set x and y' do
   y 200
 end
 
-ChefCompat::CopiedFromChef::Chef.log_deprecation "hi there"
+Chef.log_deprecation "hi there"


### PR DESCRIPTION
This was breaking custom-resources-in-library-cookbook patterns (PLEASE STOP DOING THIS JUST WRITE CUSTOM RESOURCES -- RESOURCES GO IN THE RESOURCES DIRECTORY NOT THE LIBRARIES DIRECTORY -- IT DOES NOT MAKE YOU A BETTER CHEF/RUBY DEVELOPER TO TRY TO AVOID THE DSL -- IT MAKES YOUR CODE WORSE BECAUSE YOUR ARE, IN FACT, SIMPLY IGNORANT OF THE FOOTGUNS LYING AROUND THAT THE DSL PROTECTS YOU FROM).