### PR TITLE
avoid redefining symbols

### DIFF
--- a/libraries/autoload.rb
+++ b/libraries/autoload.rb
@@ -20,10 +20,12 @@ if Gem::Requirement.new("< #{ChefCompat::CHEF_UPSTREAM_VERSION}").satisfied_by?(
   require 'compat_resource'
 else
   Chef::Log.debug "NOT LOADING compat_resource based on chef-version #{ChefCompat::CHEF_UPSTREAM_VERSION} over chef version #{Gem::Version.new(Chef::VERSION)}"
-  module ChefCompat
-    Resource = Chef::Resource
-    module Mixin
-      Properties = Chef::Mixin::Properties
+  unless defined?(Chef::Compat::Resource) && defined?(ChefCompat::Mixin::Properties)
+    module ChefCompat
+      Resource = Chef::Resource
+      module Mixin
+        Properties = Chef::Mixin::Properties
+      end
     end
   end
 end


### PR DESCRIPTION

chefspec reloads libraries constantly because chef must eval them
instead of requiring them.

Signed-off-by: Lamont Granquist <lamont@scriptkiddie.org>