### PR TITLE
Fix formatting in License section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,20 @@ Curious about how to use custom resources?
 
 ## License & Authors
 
-**Author:** John Keiser ([jkeiser@chef.io](mailto:jkeiser@chef.io))
+ - Author:: John Keiser ([jkeiser@chef.io](mailto:jkeiser@chef.io))
 
-**Copyright:** 2015-2016, Chef Software, Inc. ``` Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
+```text
+Copyright:: 2015-2016 Chef Software, Inc.
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```
-http://www.apache.org/licenses/LICENSE-2.0
-```
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.


### PR DESCRIPTION
### Description

The README has broken Markdown formatting because block-tics have to start on a new line.
and wasn't consistent with other cookbooks.
I also tweaked the formatting slightly for consistency with other cookbooks.

### Issues Resolved

I didn't create a separate Issue in GitHub.

### Check List

Obvious fix.
(so no DCO sign-off needed)