### PR TITLE
Suppress warning already initialized constant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       rvm: 2.0
     - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.1.0'; gem 'chef-zero', '< 4.6'; gem 'ffi-yajl', '< 2.3'; gem 'chef-api', '< 0.7'; gem 'ohai', '< 8.18'\""
       rvm: 2.0
-    - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.0.3'; gem 'chef-zero', '< 4.6'; gem 'ffi-yajl', '< 2.3'; gem 'chef-api', '< 0.7'; gem 'ohai', '< 8.18'\""
+    - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.0.3'; gem 'chef-zero', '< 4.6'; gem 'ffi-yajl', '< 2.3'; gem 'chef-api', '< 0.7'; gem 'ohai', '< 8.18'; gem 'nokogiri', '< 1.6.8'\""
       rvm: 2.0
     - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.14.0'\""
       rvm: 2.3.1

--- a/files/lib/chef_upstream_version.rb
+++ b/files/lib/chef_upstream_version.rb
@@ -1,3 +1,3 @@
         module ChefCompat
-          CHEF_UPSTREAM_VERSION="12.16.42"
+          CHEF_UPSTREAM_VERSION="12.16.42" unless defined? CHEF_UPSTREAM_VERSION
         end


### PR DESCRIPTION
### Description

This PR will suppress following warning while running chefspec for cookbook which includes compat_resource cookbook as dependency.

```
/tmp/chefspec20161229-27198-1do3odsfile_cache_path/cookbooks/compat_resource/files/lib/chef_upstream_version.rb:2: warning: already initialized constant ChefCompat::CHEF_UPSTREAM_VERSION
/tmp/d20161229-27198-ul2nvd/cookbooks/compat_resource/files/lib/chef_upstream_version.rb:2: warning: previous definition of CHEF_UPSTREAM_VERSION was here
```

### Issues Resolved

[List any existing issues this PR resolves] no issue submitted for this PR

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing. (this is fix for a test case)
- [x] New functionality has been documented in the README if applicable (not applicable as it's not a functionality)
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
