### PR TITLE
Install nokogiri version 1.6.7.2 for ruby 2.0 test case to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
       rvm: 2.0
     - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.1.0'; gem 'chef-zero', '< 4.6'; gem 'ffi-yajl', '< 2.3'; gem 'chef-api', '< 0.7'; gem 'ohai', '< 8.18'\""
       rvm: 2.0
-    - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.0.3'; gem 'chef-zero', '< 4.6'; gem 'ffi-yajl', '< 2.3'; gem 'chef-api', '< 0.7'; gem 'ohai', '< 8.18'\""
+    - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.0.3'; gem 'chef-zero', '< 4.6'; gem 'ffi-yajl', '< 2.3'; gem 'chef-api', '< 0.7'; gem 'ohai', '< 8.18'; gem 'nokogiri', '< 1.6.8'\""
       rvm: 2.0
     - env: "GEMFILE_MOD=\"gem 'chef', '~> 12.14.0'\""
       rvm: 2.3.1


### PR DESCRIPTION
Signed-off-by: Joel Handwell <joelhandwell@gmail.com>

### Description

Nokogiri v1.7.0 was [released](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#170--2016-12-26) on 2016-12-26. Travis fails with the test case with ruby 2.0 when it try to run bundle install because nokogiri-1.7.0 requires ruby version >= 2.1.0. This PR restrict nokogiri version under 1.6.8 to make the test case pass.

### Issues Resolved

[List any existing issues this PR resolves] no issue submitted 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing. (this is fix for a test case)
- [x] New functionality has been documented in the README if applicable (not applicable as it's not a functionality)
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
