### PR TITLE
Backport yum/apt changes from 12.19

### DIFF
--- a/files/lib/chef_compat/copied_from_chef/chef/provider/support/yum_repo.erb
+++ b/files/lib/chef_compat/copied_from_chef/chef/provider/support/yum_repo.erb
@@ -4,8 +4,13 @@
 [<%= @config.repositoryid %>]
 name=<%= @config.description %>
 <% if @config.baseurl %>
-baseurl=<%= @config.baseurl %>
-<% end %>
+baseurl=<%= case @config.baseurl
+     when Array
+       @config.baseurl.join("\n")
+     else
+       @config.baseurl
+     end %>
+<% end -%>
 <% if @config.cost %>
 cost=<%= @config.cost %>
 <% end %>
@@ -24,7 +29,9 @@ exclude=<%= @config.exclude %>
 failovermethod=<%= @config.failovermethod %>
 <% end %>
 <% if @config.fastestmirror_enabled %>
-fastestmirror_enabled=<%= @config.fastestmirror_enabled %>
+fastestmirror_enabled=1
+<% else %>
+fastestmirror_enabled=0
 <% end %>
 <% if @config.gpgcheck %>
 gpgcheck=1

--- a/files/lib/chef_compat/copied_from_chef/chef/provider/yum_repository.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/provider/yum_repository.rb
@@ -89,16 +89,15 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       end
 
       action :delete do
-        declare_resource(:file, "/etc/yum.repos.d/#{new_resource.repositoryid}.repo") do
-          action :delete
-          notifies :run, "execute[yum clean all #{new_resource.repositoryid}]", :immediately
-          notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
-        end
-
+        # clean the repo cache first
         declare_resource(:execute, "yum clean all #{new_resource.repositoryid}") do
           command "yum clean all --disablerepo=* --enablerepo=#{new_resource.repositoryid}"
-          only_if "yum repolist | grep -P '^#{new_resource.repositoryid}([ \t]|$)'"
-          action :nothing
+          only_if "yum repolist all | grep -P '^#{new_resource.repositoryid}([ \t]|$)'"
+        end
+
+        declare_resource(:file, "/etc/yum.repos.d/#{new_resource.repositoryid}.repo") do
+          action :delete
+          notifies :create, "ruby_block[yum-cache-reload-#{new_resource.repositoryid}]", :immediately
         end
 
         declare_resource(:ruby_block, "yum-cache-reload-#{new_resource.repositoryid}") do

--- a/files/lib/chef_compat/copied_from_chef/chef/resource/apt_repository.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource/apt_repository.rb
@@ -54,7 +54,6 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
 
       property :cookbook, [String, nil, false], default: nil, desired_state: false, nillable: true, coerce: proc { |x| x ? x : nil }
       property :cache_rebuild, [TrueClass, FalseClass], default: true, desired_state: false
-      property :sensitive, [TrueClass, FalseClass], default: false, desired_state: false
 
       default_action :add
       allowed_actions :add, :remove

--- a/files/lib/chef_compat/copied_from_chef/chef/resource/apt_update.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource/apt_update.rb
@@ -38,7 +38,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
   class Resource < (defined?(::Chef::Resource) ? ::Chef::Resource : Object)
     class AptUpdate < (defined?(::Chef::Resource::AptUpdate) ? ::Chef::Resource::AptUpdate : Chef::Resource)
       resource_name :apt_update
-      provides :apt_update, os: "linux"
+      provides :apt_update
 
       property :frequency, Integer, default: 86_400
 

--- a/files/lib/chef_compat/copied_from_chef/chef/resource/yum_repository.rb
+++ b/files/lib/chef_compat/copied_from_chef/chef/resource/yum_repository.rb
@@ -41,7 +41,7 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       provides :yum_repository
 
       # http://linux.die.net/man/5/yum.conf
-      property :baseurl, String, regex: /.*/
+      property :baseurl, [String, Array], regex: /.*/
       property :cost, String, regex: /^\d+$/
       property :clean_headers, [TrueClass, FalseClass], default: false # deprecated
       property :clean_metadata, [TrueClass, FalseClass], default: true
@@ -74,7 +74,6 @@ class Chef < (defined?(::Chef) ? ::Chef : Object)
       property :repo_gpgcheck, [TrueClass, FalseClass]
       property :report_instanceid, [TrueClass, FalseClass]
       property :repositoryid, String, regex: /.*/, name_property: true
-      property :sensitive, [TrueClass, FalseClass], default: false
       property :skip_if_unavailable, [TrueClass, FalseClass]
       property :source, String, regex: /.*/
       property :sslcacert, String, regex: /.*/


### PR DESCRIPTION
We can’t fully update compat_resource from 12.19 because we’d have to back port the entire deprecation class. Instead lets just pull in the bits we want this one last time.

Signed-off-by: Tim Smith <tsmith@chef.io>